### PR TITLE
v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,8 @@
-# Replacement go-ethereum/core types
+# Shared shutter transaction types / encoding lib
 
-This repository defines the modified `go-ethereum/core` types
-to be synced accros the various go-ethereum forks of shutter-network
-(cannon/minigeth, optimism/l2geth).
-
-It is possible to use the transaction types by importing this respository,
-since all necessary base-types are included in the `types/` package.
-This is useful e.g. for RLP encoding the Shutter transaction types in
-rolling shutter.
-
-## Updating shutter-network/go-ethereum type definitions
-
-With the help of the purpose built `shtypecopy` tool,
-it is easy to copy a subset of modified files 
-to the target directory, and eventually replace the 
-original packages import paths.
-
-Workflow how to update go-ethereum type definitions accross code-bases:
-
-#### 0 - Build the `shtypecopy` tool
-```sh
-git clone git@github.com:shutter-network/txtypes.git
-cd txtypes/shtypecopy
-go build
-```
-Now you can use the binary `./shtypecopy` for the instructions below.
-
-#### 1 - Make the changes to the types in the geth fork
-
-After cloning https://github.com/shutter-network/go-ethereum/ do:
-```sh
-cd go-ethereum/core/types
-git checkout shutter-types
-echo "make your changes, for example:"
-echo "// changes" >> transaction.go
-git add . -u
-git commit -m "Update type definition"
-```
-And push and merge upstream.
-
-#### 2 - Sync code in the `cannon` repo
-After cloning https://github.com/shutter-network/cannon do:
-```sh
-cd cannon/minigeth/core/types
-./shtypecopy --in core/types --out . --rules rules.shtypecopy
-git add . -u
-git commit -m "Sync types with github.com/shutter-network/go-ethereum"
-```
-And push and merge upstream.
-
-#### 3 - Sync code in the `txtypes` repo
-After cloning https://github.com/shutter-network/txtypes do:
-```sh
-cd txtypes/types
-./shtypecopy --in core/types  --out . --rules rules.shtypecopy
-git add . -u
-git commit -m "Sync types with github.com/shutter-network/go-ethereum"
-```
-
-#### 4 - Push a new semver tag
-```sh
-git tag v0.0.42
-git push --tags
-```
-And push and merge upstream.
-
-#### 5 - Update `txtypes` version in `rolling-shutter` repo
-You should wait at least 1 minute after pushing the new version in order to not poison the `proxy.golang.org` cache:
-
-> From https://proxy.golang.org/ - 
-The new version should be available within one minute. Note that if someone requested the version before the tag was pushed, it may take up to 30 minutes for the mirror's cache to expire and fresh data about the version to become available.
-
-After cloning https://github.com/shutter-network/rolling-shutter do:
-```sh
-cd rolling-shutter/rolling-shutter
-go get github.com/shutter-network/txtypes@v0.0.42
-git add . -u
-git commit -m "Update txtypes version to v0.0.42"
-```
+- Transaction type definitions for [github.com/shutter-network/rolling-shutter](https://github.com/shutter-network/rolling-shutter)
+- Loosely based on go-etherum type definitions
+- Decoding / Encoding for JSON
+- Decoding / Encoding for RLP
+- Hashing / Signature derivation
+- Decoding / Encoding for hexutil wrapper-type data class

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/go-cmp v0.5.9
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/types/access_list_tx.go
+++ b/types/access_list_tx.go
@@ -56,7 +56,7 @@ type AccessListTx struct {
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
-func (tx *AccessListTx) copy() TxData {
+func (tx *AccessListTx) copy() TxInner {
 	cpy := &AccessListTx{
 		Nonce: tx.Nonce,
 		To:    tx.To, // TODO: copy pointed-to address

--- a/types/batch_tx.go
+++ b/types/batch_tx.go
@@ -21,7 +21,7 @@ type BatchTx struct {
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
-func (tx *BatchTx) copy() TxData {
+func (tx *BatchTx) copy() TxInner {
 	cpy := &BatchTx{
 		ChainID:       new(big.Int),
 		DecryptionKey: []byte{},

--- a/types/decrypted_payload.go
+++ b/types/decrypted_payload.go
@@ -7,38 +7,31 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-type DecryptedPayload struct {
+type ShutterPayload struct {
 	To    *common.Address `rlp:"nil"`
 	Data  []byte
 	Value *big.Int
 }
 
-func (p *DecryptedPayload) AsMessage(tx *Transaction, signer Signer) (Message, error) {
-	sender, err := signer.Sender(tx)
-	if err != nil {
-		return Message{}, err
+func (p *ShutterPayload) Copy() *ShutterPayload {
+	cpy := new(ShutterPayload)
+	cpy.Data = common.CopyBytes(p.Data)
+	if p.To != nil {
+		addr := common.BytesToAddress(p.To.Bytes())
+		cpy.To = &addr
 	}
-	return NewMessage(
-		sender,        // from
-		p.To,          // to
-		tx.Nonce(),    // nonce
-		p.Value,       // amount
-		tx.Gas(),      // gas limit
-		big.NewInt(0), // gas price
-		big.NewInt(0), // gas fee cap
-		big.NewInt(0), // gas tip cap
-		p.Data,        // data
-		nil,           // access list
-		false,         // is fake
-	), nil
+	if p.Value != nil {
+		cpy.Value = new(big.Int).Set(p.Value)
+	}
+	return cpy
 }
 
-func (p *DecryptedPayload) Encode() ([]byte, error) {
+func (p *ShutterPayload) Encode() ([]byte, error) {
 	return rlp.EncodeToBytes(*p)
 }
 
-func DecodeDecryptedPayload(b []byte) (*DecryptedPayload, error) {
-	p := &DecryptedPayload{}
+func DecodeShutterPayload(b []byte) (*ShutterPayload, error) {
+	p := &ShutterPayload{}
 	err := rlp.DecodeBytes(b, p)
 	return p, err
 }

--- a/types/dynamic_fee_tx.go
+++ b/types/dynamic_fee_tx.go
@@ -40,7 +40,7 @@ type DynamicFeeTx struct {
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
-func (tx *DynamicFeeTx) copy() TxData {
+func (tx *DynamicFeeTx) copy() TxInner {
 	cpy := &DynamicFeeTx{
 		Nonce: tx.Nonce,
 		To:    tx.To, // TODO: copy pointed-to address

--- a/types/legacy_tx.go
+++ b/types/legacy_tx.go
@@ -59,7 +59,7 @@ func NewContractCreation(nonce uint64, amount *big.Int, gasLimit uint64, gasPric
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
-func (tx *LegacyTx) copy() TxData {
+func (tx *LegacyTx) copy() TxInner {
 	cpy := &LegacyTx{
 		Nonce: tx.Nonce,
 		To:    tx.To, // TODO: copy pointed-to address

--- a/types/shutter_tx.go
+++ b/types/shutter_tx.go
@@ -24,7 +24,7 @@ type ShutterTx struct {
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
-func (tx *ShutterTx) copy() TxData {
+func (tx *ShutterTx) copy() TxInner {
 	cpy := &ShutterTx{
 		Nonce: tx.Nonce,
 		Gas:   tx.Gas,

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -248,6 +248,10 @@ func isProtectedV(V *big.Int) bool {
 	return true
 }
 
+func (tx *Transaction) TxInner() TxInner {
+	return tx.inner.copy()
+}
+
 // Protected says whether the transaction is replay-protected.
 func (tx *Transaction) Protected() bool {
 	switch tx := tx.inner.(type) {

--- a/types/transaction_extension.go
+++ b/types/transaction_extension.go
@@ -2,7 +2,7 @@ package types
 
 import "math/big"
 
-type TxDataExtension interface {
+type TxInnerExtension interface {
 	encryptedPayload() []byte
 	decryptionKey() []byte
 	batchIndex() uint64

--- a/types/transaction_marshalling.go
+++ b/types/transaction_marshalling.go
@@ -145,7 +145,7 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 	}
 
 	// Decode / verify fields according to transaction type.
-	var inner TxData
+	var inner TxInner
 	switch dec.Type {
 	case LegacyTxType:
 		var itx LegacyTx

--- a/types/transaction_marshalling.go
+++ b/types/transaction_marshalling.go
@@ -154,7 +154,11 @@ func (t *Transaction) TransactionData() (enc *TransactionData) {
 		enc.EncryptedPayload = (*hexutil.Bytes)(&tx.EncryptedPayload)
 		enc.L1BlockNumber = (*hexutil.Uint64)(&tx.L1BlockNumber)
 		enc.BatchIndex = (*hexutil.Uint64)(&tx.BatchIndex)
-		enc.To = t.To()
+		if tx.Payload != nil {
+			enc.To = tx.Payload.To
+			enc.Input = (*hexutil.Bytes)(&tx.Payload.Data)
+			enc.Value = (*hexutil.Big)(tx.Payload.Value)
+		}
 		enc.V = (*hexutil.Big)(tx.V)
 		enc.R = (*hexutil.Big)(tx.R)
 		enc.S = (*hexutil.Big)(tx.S)
@@ -170,7 +174,6 @@ func (t *Transaction) TransactionData() (enc *TransactionData) {
 		enc.DecryptionKey = (*hexutil.Bytes)(&tx.DecryptionKey)
 		enc.L1BlockNumber = (*hexutil.Uint64)(&tx.L1BlockNumber)
 		enc.BatchIndex = (*hexutil.Uint64)(&tx.BatchIndex)
-		enc.To = t.To()
 		enc.V = (*hexutil.Big)(tx.V)
 		enc.R = (*hexutil.Big)(tx.R)
 		enc.S = (*hexutil.Big)(tx.S)

--- a/types/transaction_signing.go
+++ b/types/transaction_signing.go
@@ -347,7 +347,7 @@ func (s eip2930Signer) Hash(tx *Transaction) common.Hash {
 		// This _should_ not happen, but in case someone sends in a bad
 		// json struct via RPC, it's probably more prudent to return an
 		// empty hash instead of killing the node with a panic
-		//panic("Unsupported transaction type: %d", tx.typ)
+		// panic("Unsupported transaction type: %d", tx.typ)
 		return common.Hash{}
 	}
 }

--- a/types/transaction_signing.go
+++ b/types/transaction_signing.go
@@ -101,7 +101,7 @@ func SignTx(tx *Transaction, s Signer, prv *ecdsa.PrivateKey) (*Transaction, err
 }
 
 // SignNewTx creates a transaction and signs it.
-func SignNewTx(prv *ecdsa.PrivateKey, s Signer, txdata TxData) (*Transaction, error) {
+func SignNewTx(prv *ecdsa.PrivateKey, s Signer, txdata TxInner) (*Transaction, error) {
 	tx := NewTx(txdata)
 	h := s.Hash(tx)
 	sig, err := crypto.Sign(h[:], prv)
@@ -113,7 +113,7 @@ func SignNewTx(prv *ecdsa.PrivateKey, s Signer, txdata TxData) (*Transaction, er
 
 // MustSignNewTx creates a transaction and signs it.
 // This panics if the transaction cannot be signed.
-func MustSignNewTx(prv *ecdsa.PrivateKey, s Signer, txdata TxData) *Transaction {
+func MustSignNewTx(prv *ecdsa.PrivateKey, s Signer, txdata TxInner) *Transaction {
 	tx, err := SignNewTx(prv, s, txdata)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR mainly implements:
- `BatchTx` and `ShutterTx` JSON encoding - useful for retrieving sequenced Shutter-transactions via the `shutter_getTransactionByHash` RPC method
- a public intermediary data class `TransactionData` with `hexutil` wrapped-types, used for JSON encoding/decoding
- a Shutter-Payload field in the `ShutterTx` struct, which is useful for internally caching decrypted payloads without exposing it to the RLP / Hashing scheme
- a public `TxInner` getter for classes implementing `Transaction` interface

This version is the first step towards https://github.com/shutter-network/txtypes/issues/2 - although it does not remove any non-shutter transactions yet.

